### PR TITLE
feat: support Playwright proxy configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ CPA_KEY=your_key
 # API 鉴权（不设置则不启用，任何人都可访问）
 API_KEY=
 
+# Playwright 浏览器代理（可选）
+# 示例：socks5://user:pass@host.docker.internal:1080
+PLAYWRIGHT_PROXY_URL=
+# 示例：localhost,127.0.0.1
+PLAYWRIGHT_PROXY_BYPASS=
+
 # 轮询配置
 EMAIL_POLL_INTERVAL=3
 EMAIL_POLL_TIMEOUT=300

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   autoteam:
     build: .
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "8787:8787"
     volumes:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,9 +17,33 @@ cp .env.example .env
 | `CPA_URL` | CLIProxyAPI 地址 | 否（默认 `http://127.0.0.1:8317`） |
 | `CPA_KEY` | CPA 管理密钥 | 是 |
 | `API_KEY` | Web 面板 / API 鉴权密钥 | 否（首次启动自动生成） |
+| `PLAYWRIGHT_PROXY_URL` | Playwright 浏览器代理 URL，如 `socks5://user:pass@host:port` | 否 |
+| `PLAYWRIGHT_PROXY_BYPASS` | Playwright 代理绕过列表，如 `localhost,127.0.0.1` | 否 |
 | `AUTO_CHECK_THRESHOLD` | 额度低于此百分比触发轮转 | 否（默认 `10`） |
 | `AUTO_CHECK_INTERVAL` | 巡检间隔（秒） | 否（默认 `300`） |
 | `AUTO_CHECK_MIN_LOW` | 至少几个账号低于阈值才触发 | 否（默认 `2`） |
+
+## Playwright 代理
+
+AutoTeam 的浏览器流量（ChatGPT 登录、邀请接受、Codex OAuth 等）现在支持单独配置代理。
+
+推荐优先使用一个环境变量：
+
+```dotenv
+PLAYWRIGHT_PROXY_URL=socks5://host.docker.internal:1080
+PLAYWRIGHT_PROXY_BYPASS=localhost,127.0.0.1
+```
+
+如果代理需要认证，也可以直接写进 URL：
+
+```dotenv
+PLAYWRIGHT_PROXY_URL=socks5://username:password@host.docker.internal:1080
+```
+
+说明：
+
+- `PLAYWRIGHT_PROXY_URL` 会被解析为 Playwright 所需的 `server` / `username` / `password` 字段
+- `PLAYWRIGHT_PROXY_BYPASS` 建议至少包含 `localhost,127.0.0.1`，避免本地回调或容器内本地服务误走代理
 
 ### 内联注释
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,6 +118,26 @@ docker compose restart
 
 直接打开 `http://your-server:8787`，会显示配置向导页面，在浏览器中填写。
 
+如果你需要让浏览器流量走宿主机 SOCKS5 代理，在 Linux Docker 下还需要给容器增加：
+
+```yaml
+extra_hosts:
+  - "host.docker.internal:host-gateway"
+```
+
+然后在 `data/.env` 中加入：
+
+```dotenv
+PLAYWRIGHT_PROXY_URL=socks5://host.docker.internal:1080
+PLAYWRIGHT_PROXY_BYPASS=localhost,127.0.0.1
+```
+
+如果代理需要认证，可以写成：
+
+```dotenv
+PLAYWRIGHT_PROXY_URL=socks5://username:password@host.docker.internal:1080
+```
+
 ## 第三步：管理员登录
 
 配置完成后，需要先用 ChatGPT Team 管理员账号登录。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -40,10 +40,11 @@ AUTO_CHECK_INTERVAL=300  # 5 分钟
 ### Codex OAuth 登录失败：未获取到 authorization code
 
 常见原因：
-1. **IP 被标记** — VPS 的 IP 被 OpenAI / Cloudflare 拦截，建议换住宅代理
+1. **IP 被标记** — VPS 的 IP 被 OpenAI/Cloudflare 拦截，建议换住宅代理
 2. **Cloudflare 验证** — 浏览器环境被检测，需更新 Chromium 或切换网络
 3. **workspace 选择失败** — 页面结构变化，查看 `screenshots/codex_04_*.png`
 4. **自动回调不可达** — 如果浏览器和 AutoTeam 不在同一台机器，`localhost:1455` 回调可能不会到达 AutoTeam，此时请改用手动粘贴回调 URL
+5. **本地回调被代理拦截** — 如果启用了 `PLAYWRIGHT_PROXY_URL`，建议同时设置 `PLAYWRIGHT_PROXY_BYPASS=localhost,127.0.0.1`
 
 ### 登录后 plan 显示 free 而不是 team
 
@@ -165,6 +166,28 @@ sudo chmod -R 777 data/
 ```yaml
 volumes:
   - ./data:/app/data
+```
+
+### 容器里访问不到宿主机 SOCKS5 代理
+
+如果代理在宿主机上，比如 `host.docker.internal:1080`，Linux Docker 需要给容器补一条 host-gateway 映射：
+
+```yaml
+extra_hosts:
+  - "host.docker.internal:host-gateway"
+```
+
+然后在 `data/.env` 中配置：
+
+```dotenv
+PLAYWRIGHT_PROXY_URL=socks5://host.docker.internal:1080
+PLAYWRIGHT_PROXY_BYPASS=localhost,127.0.0.1
+```
+
+如果代理需要认证，可以直接写成：
+
+```dotenv
+PLAYWRIGHT_PROXY_URL=socks5://username:password@host.docker.internal:1080
 ```
 
 ## Web 面板相关

--- a/src/autoteam/api.py
+++ b/src/autoteam/api.py
@@ -74,6 +74,8 @@ class SetupConfig(BaseModel):
     CLOUDMAIL_DOMAIN: str = ""
     CPA_URL: str = "http://127.0.0.1:8317"
     CPA_KEY: str = ""
+    PLAYWRIGHT_PROXY_URL: str = ""
+    PLAYWRIGHT_PROXY_BYPASS: str = ""
     API_KEY: str = ""
 
 
@@ -105,8 +107,9 @@ def post_setup_save(config: SetupConfig):
     if not data.get("API_KEY"):
         data["API_KEY"] = _secrets.token_urlsafe(24)
 
+    clearable_fields = {"PLAYWRIGHT_PROXY_URL", "PLAYWRIGHT_PROXY_BYPASS"}
     for key, value in data.items():
-        if value:
+        if value or key in clearable_fields:
             _write_env(key, value)
             os.environ[key] = value
 

--- a/src/autoteam/chatgpt_api.py
+++ b/src/autoteam/chatgpt_api.py
@@ -17,6 +17,7 @@ from autoteam.admin_state import (
     get_chatgpt_workspace_name,
     update_admin_state,
 )
+from autoteam.config import get_playwright_launch_options
 from autoteam.textio import read_text
 
 logger = logging.getLogger(__name__)
@@ -114,10 +115,7 @@ class ChatGPTTeamAPI:
     def _launch_browser(self):
         SCREENSHOT_DIR.mkdir(exist_ok=True)
         self.playwright = sync_playwright().start()
-        self.browser = self.playwright.chromium.launch(
-            headless=False,
-            args=["--disable-blink-features=AutomationControlled", "--no-sandbox"],
-        )
+        self.browser = self.playwright.chromium.launch(**get_playwright_launch_options())
         self.context = self.browser.new_context(
             viewport={"width": 1280, "height": 800},
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",

--- a/src/autoteam/codex_auth.py
+++ b/src/autoteam/codex_auth.py
@@ -20,6 +20,7 @@ from autoteam.admin_state import (
     get_chatgpt_workspace_name,
 )
 from autoteam.auth_storage import AUTH_DIR, ensure_auth_dir, ensure_auth_file_permissions
+from autoteam.config import get_playwright_launch_options
 from autoteam.textio import write_text
 
 logger = logging.getLogger(__name__)
@@ -265,10 +266,7 @@ def login_codex_via_browser(email, password, mail_client=None):
     auth_code = None
 
     with sync_playwright() as p:
-        browser = p.chromium.launch(
-            headless=False,
-            args=["--disable-blink-features=AutomationControlled", "--no-sandbox"],
-        )
+        browser = p.chromium.launch(**get_playwright_launch_options())
         context = browser.new_context(
             viewport={"width": 1280, "height": 800},
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",

--- a/src/autoteam/config.py
+++ b/src/autoteam/config.py
@@ -2,6 +2,7 @@
 
 import os
 from pathlib import Path
+from urllib.parse import unquote, urlsplit
 
 from autoteam.textio import parse_env_line, parse_env_value, read_text
 
@@ -46,3 +47,62 @@ API_KEY = os.environ.get("API_KEY", "")
 AUTO_CHECK_INTERVAL = _get_int_env("AUTO_CHECK_INTERVAL", 300)  # 巡检间隔（秒），默认 5 分钟
 AUTO_CHECK_THRESHOLD = _get_int_env("AUTO_CHECK_THRESHOLD", 10)  # 额度低于此百分比触发轮转，默认 10%
 AUTO_CHECK_MIN_LOW = _get_int_env("AUTO_CHECK_MIN_LOW", 2)  # 至少几个账号低于阈值才触发，默认 2
+
+# Playwright 代理配置
+PLAYWRIGHT_PROXY_URL = os.environ.get("PLAYWRIGHT_PROXY_URL", "").strip()
+PLAYWRIGHT_PROXY_SERVER = os.environ.get("PLAYWRIGHT_PROXY_SERVER", "").strip()
+PLAYWRIGHT_PROXY_USERNAME = os.environ.get("PLAYWRIGHT_PROXY_USERNAME", "").strip()
+PLAYWRIGHT_PROXY_PASSWORD = os.environ.get("PLAYWRIGHT_PROXY_PASSWORD", "").strip()
+PLAYWRIGHT_PROXY_BYPASS = os.environ.get("PLAYWRIGHT_PROXY_BYPASS", "").strip()
+
+
+def _format_proxy_host(hostname: str) -> str:
+    if ":" in hostname and not hostname.startswith("["):
+        return f"[{hostname}]"
+    return hostname
+
+
+def _parse_proxy_url(proxy_url: str):
+    if "://" not in proxy_url:
+        return {"server": proxy_url}
+
+    parsed = urlsplit(proxy_url)
+    if not parsed.scheme or not parsed.hostname:
+        return {"server": proxy_url}
+
+    host = _format_proxy_host(parsed.hostname)
+    server = f"{parsed.scheme}://{host}"
+    if parsed.port:
+        server = f"{server}:{parsed.port}"
+
+    proxy = {"server": server}
+    if parsed.username:
+        proxy["username"] = unquote(parsed.username)
+    if parsed.password:
+        proxy["password"] = unquote(parsed.password)
+    return proxy
+
+
+def get_playwright_launch_options():
+    """统一的 Playwright Chromium 启动参数。"""
+    options = {
+        "headless": False,
+        "args": ["--disable-blink-features=AutomationControlled", "--no-sandbox"],
+    }
+
+    proxy = None
+    if PLAYWRIGHT_PROXY_URL:
+        proxy = _parse_proxy_url(PLAYWRIGHT_PROXY_URL)
+    elif PLAYWRIGHT_PROXY_SERVER:
+        proxy = {"server": PLAYWRIGHT_PROXY_SERVER}
+        if PLAYWRIGHT_PROXY_USERNAME:
+            proxy["username"] = PLAYWRIGHT_PROXY_USERNAME
+        if PLAYWRIGHT_PROXY_PASSWORD:
+            proxy["password"] = PLAYWRIGHT_PROXY_PASSWORD
+
+    if proxy:
+        if PLAYWRIGHT_PROXY_BYPASS:
+            proxy["bypass"] = PLAYWRIGHT_PROXY_BYPASS
+        options["proxy"] = proxy
+
+    return options

--- a/src/autoteam/invite.py
+++ b/src/autoteam/invite.py
@@ -26,6 +26,7 @@ from playwright.sync_api import sync_playwright
 
 from autoteam.chatgpt_api import ChatGPTTeamAPI
 from autoteam.cloudmail import CloudMailClient
+from autoteam.config import get_playwright_launch_options
 
 logger = logging.getLogger(__name__)
 
@@ -403,10 +404,7 @@ def run():
         logger.info("[邀请] 开始注册 ChatGPT 账号")
 
         with sync_playwright() as p:
-            browser = p.chromium.launch(
-                headless=False,
-                args=["--disable-blink-features=AutomationControlled", "--no-sandbox"],
-            )
+            browser = p.chromium.launch(**get_playwright_launch_options())
             context = browser.new_context(
                 viewport={"width": 1280, "height": 800},
                 user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",

--- a/src/autoteam/manager.py
+++ b/src/autoteam/manager.py
@@ -57,6 +57,7 @@ from autoteam.codex_auth import (
     refresh_main_auth_file,
     save_auth_file,
 )
+from autoteam.config import get_playwright_launch_options
 from autoteam.cpa_sync import sync_from_cpa, sync_main_codex_to_cpa, sync_to_cpa
 from autoteam.textio import read_text, write_text
 
@@ -665,10 +666,7 @@ def _complete_registration(email, password, invite_link, mail_client):
 
     logger.info("[注册] 开始注册 %s...", email)
     with sync_playwright() as p:
-        browser = p.chromium.launch(
-            headless=False,
-            args=["--disable-blink-features=AutomationControlled", "--no-sandbox"],
-        )
+        browser = p.chromium.launch(**get_playwright_launch_options())
         context = browser.new_context(
             viewport={"width": 1280, "height": 800},
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
@@ -1140,13 +1138,9 @@ def _register_direct_once(mail_client, email, password, cloudmail_account_id=Non
     signup_url = "https://chatgpt.com/auth/login"
 
     with sync_playwright() as p:
-        launch_kwargs = {
-            "headless": False,
-            "args": ["--disable-blink-features=AutomationControlled", "--no-sandbox"],
-        }
+        launch_kwargs = get_playwright_launch_options()
         if sys.platform.startswith("win"):
             launch_kwargs["slow_mo"] = 100
-
         browser = p.chromium.launch(**launch_kwargs)
         context = browser.new_context(
             viewport={"width": 1280, "height": 800},
@@ -1503,10 +1497,7 @@ def reinvite_account(chatgpt_api, mail_client, acc):
         chatgpt_api.stop()
 
     with sync_playwright() as p:
-        browser = p.chromium.launch(
-            headless=False,
-            args=["--disable-blink-features=AutomationControlled", "--no-sandbox"],
-        )
+        browser = p.chromium.launch(**get_playwright_launch_options())
         context = browser.new_context(
             viewport={"width": 1280, "height": 800},
             user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",

--- a/src/autoteam/setup_wizard.py
+++ b/src/autoteam/setup_wizard.py
@@ -22,6 +22,8 @@ REQUIRED_CONFIGS = [
     ("CLOUDMAIL_DOMAIN", "CloudMail 邮箱域名（如 @example.com）", "", False),
     ("CPA_URL", "CPA (CLIProxyAPI) 地址", "http://127.0.0.1:8317", True),
     ("CPA_KEY", "CPA 管理密钥", "", False),
+    ("PLAYWRIGHT_PROXY_URL", "Playwright 浏览器代理 URL（可选，如 socks5://host:port）", "", True),
+    ("PLAYWRIGHT_PROXY_BYPASS", "Playwright 代理绕过列表（可选，如 localhost,127.0.0.1）", "", True),
     ("API_KEY", "API 鉴权密钥（回车自动生成）", "", True),
 ]
 
@@ -79,7 +81,7 @@ def check_and_setup(interactive: bool = True) -> bool:
 
     for key, prompt, default, optional in REQUIRED_CONFIGS:
         val = env.get(key, "") or os.environ.get(key, "")
-        if not val:
+        if not val and not optional:
             missing.append((key, prompt, default, optional))
 
     if not missing:

--- a/tests/unit/test_setup_wizard.py
+++ b/tests/unit/test_setup_wizard.py
@@ -80,6 +80,9 @@ def test_check_and_setup_non_interactive_reports_missing_required_fields(tmp_pat
 
     assert ok is False
     assert "[配置] 缺少必填项: CLOUDMAIL_BASE_URL" in caplog.text
-    assert "[配置] 缺少必填项: CPA_URL" in caplog.text
-    assert "[配置] 缺少必填项: API_KEY" in caplog.text
+    assert "[配置] 缺少必填项: CPA_KEY" in caplog.text
+    assert "[配置] 缺少必填项: CPA_URL" not in caplog.text
+    assert "[配置] 缺少必填项: PLAYWRIGHT_PROXY_URL" not in caplog.text
+    assert "[配置] 缺少必填项: PLAYWRIGHT_PROXY_BYPASS" not in caplog.text
+    assert "[配置] 缺少必填项: API_KEY" not in caplog.text
     assert "[配置] 请通过 Web 面板或编辑 .env 文件填入配置" in caplog.text


### PR DESCRIPTION
## Summary
- add unified Playwright proxy config with `PLAYWRIGHT_PROXY_URL` and optional bypass support
- route all Chromium launch points through shared launch options
- document Docker host SOCKS5 setup and expose proxy fields in `.env.example` and setup wizard

## Testing
- python -m compileall src/autoteam