### PR TITLE
fix: 持久化自动巡检触发轮转前的额度元数据

### DIFF
--- a/src/autoteam/api.py
+++ b/src/autoteam/api.py
@@ -1675,10 +1675,15 @@ def _auto_check_loop():
 
                 for email, remaining, status, info in low_accounts:
                     logger.info("[巡检] %s 剩余 %d%%，标记为 exhausted", email, remaining)
-                    status_kwargs = {"status": STATUS_EXHAUSTED, "quota_exhausted_at": time.time()}
+                    status_kwargs = {
+                        "status": STATUS_EXHAUSTED,
+                        "quota_exhausted_at": time.time(),
+                    }
                     if status == "ok":
                         status_kwargs["last_quota"] = info if isinstance(info, dict) else None
-                        status_kwargs["quota_resets_at"] = info.get("primary_resets_at") if isinstance(info, dict) else None
+                        status_kwargs["quota_resets_at"] = (
+                            info.get("primary_resets_at") if isinstance(info, dict) else None
+                        )
                     else:
                         status_kwargs["last_quota"] = quota_result_quota_info(info)
                         status_kwargs["quota_resets_at"] = quota_result_resets_at(info)

--- a/src/autoteam/api.py
+++ b/src/autoteam/api.py
@@ -1649,15 +1649,17 @@ def _auto_check_loop():
                     if status == "ok" and isinstance(info, dict):
                         remaining = 100 - info.get("primary_pct", 0)
                         if remaining < cfg["threshold"]:
-                            low_accounts.append((acc["email"], remaining))
+                            low_accounts.append((acc["email"], remaining, status, info))
                     elif status == "exhausted":
-                        low_accounts.append((acc["email"], 0))
+                        low_accounts.append((acc["email"], 0, status, info))
                 except Exception:
                     pass
 
             if low_accounts:
                 logger.info(
-                    "[巡检] %d 个账号额度不足: %s", len(low_accounts), ", ".join(f"{e}({r}%)" for e, r in low_accounts)
+                    "[巡检] %d 个账号额度不足: %s",
+                    len(low_accounts),
+                    ", ".join(f"{e}({r}%)" for e, r, _status, _info in low_accounts),
                 )
 
             if len(low_accounts) >= cfg["min_low"]:
@@ -1669,10 +1671,18 @@ def _auto_check_loop():
 
                 # 将低于阈值的账号标记为 exhausted，rotate 会自动移出并补充
                 from autoteam.accounts import STATUS_EXHAUSTED, update_account
+                from autoteam.codex_auth import quota_result_quota_info, quota_result_resets_at
 
-                for email, remaining in low_accounts:
+                for email, remaining, status, info in low_accounts:
                     logger.info("[巡检] %s 剩余 %d%%，标记为 exhausted", email, remaining)
-                    update_account(email, status=STATUS_EXHAUSTED, quota_exhausted_at=time.time())
+                    status_kwargs = {"status": STATUS_EXHAUSTED, "quota_exhausted_at": time.time()}
+                    if status == "ok":
+                        status_kwargs["last_quota"] = info if isinstance(info, dict) else None
+                        status_kwargs["quota_resets_at"] = info.get("primary_resets_at") if isinstance(info, dict) else None
+                    else:
+                        status_kwargs["last_quota"] = quota_result_quota_info(info)
+                        status_kwargs["quota_resets_at"] = quota_result_resets_at(info)
+                    update_account(email, **status_kwargs)
 
                 logger.info("[巡检] 触发自动轮转...")
                 from autoteam.manager import cmd_rotate

--- a/tests/unit/test_api_status.py
+++ b/tests/unit/test_api_status.py
@@ -102,3 +102,84 @@ def test_post_setup_save_keeps_cpa_url_required_and_generates_api_key(monkeypatc
     assert written["API_KEY"] == "generated-token"
     assert result["api_key"] == "generated-token"
     assert api.API_KEY == "generated-token"
+
+
+def test_auto_check_persists_reuse_blocking_metadata_before_rotate(tmp_path, monkeypatch):
+    low_auth = tmp_path / "low.json"
+    exhausted_auth = tmp_path / "exhausted.json"
+    low_auth.write_text('{"access_token": "token-low"}', encoding="utf-8")
+    exhausted_auth.write_text('{"access_token": "token-exhausted"}', encoding="utf-8")
+
+    updates = []
+
+    def fake_update_account(email, **kwargs):
+        updates.append((email, kwargs))
+
+    monkeypatch.setattr(api, "_auto_check_config", {"interval": 0, "threshold": 10, "min_low": 2})
+    monkeypatch.setattr(api, "_auto_check_stop", __import__("threading").Event())
+    monkeypatch.setattr(api, "_auto_check_restart", __import__("threading").Event())
+    monkeypatch.setattr(api, "_is_main_account_email", lambda _email: False)
+    monkeypatch.setattr(
+        "autoteam.accounts.load_accounts",
+        lambda: [
+            {"email": "low@example.com", "status": "active", "auth_file": str(low_auth)},
+            {"email": "exhausted@example.com", "status": "active", "auth_file": str(exhausted_auth)},
+        ],
+    )
+    monkeypatch.setattr(
+        "autoteam.codex_auth.check_codex_quota",
+        lambda token: (
+            ("ok", {"primary_pct": 93, "primary_resets_at": 1234567890, "weekly_pct": 1, "weekly_resets_at": 0})
+            if token == "token-low"
+            else (
+                "exhausted",
+                {
+                    "resets_at": 2222222222,
+                    "quota_info": {
+                        "primary_pct": 100,
+                        "primary_resets_at": 2222222222,
+                        "weekly_pct": 100,
+                        "weekly_resets_at": 0,
+                    },
+                },
+            )
+        ),
+    )
+    monkeypatch.setattr("autoteam.accounts.update_account", fake_update_account)
+    monkeypatch.setattr("autoteam.manager.cmd_rotate", lambda *args, **kwargs: None)
+    monkeypatch.setattr(api, "_start_task", lambda *args, **kwargs: None)
+
+    stop_event = api._auto_check_stop
+    wait_calls = {"count": 0}
+
+    def fake_wait(_seconds):
+        wait_calls["count"] += 1
+        return wait_calls["count"] > 1
+
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    api._auto_check_loop()
+
+    assert len(updates) == 2
+    low_update = next(kwargs for email, kwargs in updates if email == "low@example.com")
+    exhausted_update = next(kwargs for email, kwargs in updates if email == "exhausted@example.com")
+
+    assert low_update["status"] == "exhausted"
+    assert low_update["quota_exhausted_at"]
+    assert low_update["last_quota"] == {
+        "primary_pct": 93,
+        "primary_resets_at": 1234567890,
+        "weekly_pct": 1,
+        "weekly_resets_at": 0,
+    }
+    assert low_update["quota_resets_at"] == 1234567890
+
+    assert exhausted_update["status"] == "exhausted"
+    assert exhausted_update["quota_exhausted_at"]
+    assert exhausted_update["last_quota"] == {
+        "primary_pct": 100,
+        "primary_resets_at": 2222222222,
+        "weekly_pct": 100,
+        "weekly_resets_at": 0,
+    }
+    assert exhausted_update["quota_resets_at"] == 2222222222


### PR DESCRIPTION
## 问题

自动巡检发现账号额度低于阈值后，会先将账号标记为 `exhausted`，再触发 `rotate`。

但这条路径此前只持久化了：

- `status`
- `quota_exhausted_at`

没有同步保存最新的：

- `last_quota`
- `quota_resets_at`

这会导致后续 standby 复用 fallback 在无法再次做 live quota 校验时，只能依赖本地过期或缺失的额度信息，从而误判账号可复用，出现刚被移出的低额度账号又被重新拉回 Team 的情况。

## 修改

在 `src/autoteam/api.py::_auto_check_loop()` 中，自动巡检将账号标记为 `exhausted` 时，同时持久化额度相关元数据：

- `last_quota`
- `quota_resets_at`
- `quota_exhausted_at`

具体处理逻辑：

- 当 `check_codex_quota()` 返回 `status == ok` 且剩余额度低于阈值时：
  - 保存实时 quota snapshot 到 `last_quota`
  - 保存 `primary_resets_at` 到 `quota_resets_at`

- 当 `check_codex_quota()` 返回 `status == exhausted` 时：
  - 保存 `quota_result_quota_info(info)` 到 `last_quota`
  - 保存 `quota_result_resets_at(info)` 到 `quota_resets_at`

## 影响

这次修改只修复自动巡检触发轮转前的持久化缺口，不调整 rotate / standby 复用策略本身。

这样可以确保：
- 巡检判定为低额度的账号在被移出后，fallback 复用逻辑能读取到最新的恢复时间
- 避免刚被标记 exhausted 的账号因为本地额度信息缺失而被立即复用

## 测试

新增回归测试，覆盖自动巡检在触发 rotate 前持久化以下字段的行为：

- `status=exhausted`
- `quota_exhausted_at`
- `last_quota`
- `quota_resets_at`

另外已完成本地代码检查与相关验证。