### PR TITLE
fix: retry auto rotate when active seats are low

### DIFF
--- a/src/autoteam/api.py
+++ b/src/autoteam/api.py
@@ -1607,6 +1607,8 @@ def _auto_check_loop():
     from autoteam.accounts import STATUS_ACTIVE, load_accounts
     from autoteam.codex_auth import check_codex_quota
 
+    target_seats = 5
+
     while not _auto_check_stop.is_set():
         cfg = _auto_check_config
         logger.info(
@@ -1626,6 +1628,9 @@ def _auto_check_loop():
         try:
             cfg = _auto_check_config  # 重新读取
             accounts = load_accounts()
+            local_active_count = sum(
+                1 for a in accounts if a["status"] == STATUS_ACTIVE and not _is_main_account_email(a.get("email"))
+            )
             active = [
                 a
                 for a in accounts
@@ -1634,9 +1639,6 @@ def _auto_check_loop():
                 and a.get("auth_file")
                 and Path(a["auth_file"]).exists()
             ]
-
-            if not active:
-                continue
 
             low_accounts = []
             for acc in active:
@@ -1662,10 +1664,13 @@ def _auto_check_loop():
                     ", ".join(f"{e}({r}%)" for e, r, _status, _info in low_accounts),
                 )
 
-            if len(low_accounts) >= cfg["min_low"]:
+            shortage = max(0, target_seats - local_active_count)
+            trigger_rotate = len(low_accounts) >= cfg["min_low"] or shortage > 0
+
+            if trigger_rotate:
                 # 检查是否有任务在跑
                 if not _playwright_lock.acquire(blocking=False):
-                    logger.info("[巡检] 有任务正在执行，跳过本轮自动轮转")
+                    logger.info("[巡检] 有任务正在执行，跳过本轮自动轮转/补位")
                     continue
                 _playwright_lock.release()
 
@@ -1683,21 +1688,40 @@ def _auto_check_loop():
                         status_kwargs["last_quota"] = info if isinstance(info, dict) else None
                         status_kwargs["quota_resets_at"] = (
                             info.get("primary_resets_at") if isinstance(info, dict) else None
-                        )
+                        ) or int(time.time() + 18000)
                     else:
                         status_kwargs["last_quota"] = quota_result_quota_info(info)
-                        status_kwargs["quota_resets_at"] = quota_result_resets_at(info)
+                        status_kwargs["quota_resets_at"] = quota_result_resets_at(info) or int(time.time() + 18000)
                     update_account(email, **status_kwargs)
 
-                logger.info("[巡检] 触发自动轮转...")
+                if shortage > 0 and len(low_accounts) >= cfg["min_low"]:
+                    logger.info(
+                        "[巡检] 当前 active 数不足: %d/%d，且检测到低额度账号，触发自动轮转...",
+                        local_active_count,
+                        target_seats,
+                    )
+                elif shortage > 0:
+                    logger.info("[巡检] 当前 active 数不足: %d/%d，触发自动补位...", local_active_count, target_seats)
+                else:
+                    logger.info("[巡检] 触发自动轮转...")
                 from autoteam.manager import cmd_rotate
 
                 try:
-                    _start_task("auto-rotate", cmd_rotate, {"target": 5, "trigger": "auto-check"}, 5)
+                    _start_task(
+                        "auto-rotate",
+                        cmd_rotate,
+                        {
+                            "target": target_seats,
+                            "trigger": "auto-check",
+                            "shortage": shortage,
+                            "low_accounts": len(low_accounts),
+                        },
+                        target_seats,
+                    )
                 except Exception as e:
                     logger.error("[巡检] 自动轮转失败: %s", e)
             else:
-                logger.info("[巡检] 额度正常，无需轮转")
+                logger.info("[巡检] 额度正常且 active 数充足（%d/%d），无需轮转", local_active_count, target_seats)
 
         except Exception as e:
             logger.error("[巡检] 巡检异常: %s", e)

--- a/tests/unit/test_api_status.py
+++ b/tests/unit/test_api_status.py
@@ -183,3 +183,160 @@ def test_auto_check_persists_reuse_blocking_metadata_before_rotate(tmp_path, mon
         "weekly_resets_at": 0,
     }
     assert exhausted_update["quota_resets_at"] == 2222222222
+
+
+def test_auto_check_falls_back_when_ok_quota_has_no_reset_time(tmp_path, monkeypatch):
+    auth_file = tmp_path / "low.json"
+    auth_file.write_text('{"access_token": "token-low"}', encoding="utf-8")
+
+    updates = []
+
+    def fake_update_account(email, **kwargs):
+        updates.append((email, kwargs))
+
+    monkeypatch.setattr(api, "_auto_check_config", {"interval": 0, "threshold": 10, "min_low": 1})
+    monkeypatch.setattr(api, "_auto_check_stop", __import__("threading").Event())
+    monkeypatch.setattr(api, "_auto_check_restart", __import__("threading").Event())
+    monkeypatch.setattr(api, "_is_main_account_email", lambda _email: False)
+    monkeypatch.setattr(
+        "autoteam.accounts.load_accounts",
+        lambda: [{"email": "low@example.com", "status": "active", "auth_file": str(auth_file)}],
+    )
+    monkeypatch.setattr(
+        "autoteam.codex_auth.check_codex_quota",
+        lambda _token: ("ok", {"primary_pct": 93, "weekly_pct": 1, "weekly_resets_at": 0}),
+    )
+    monkeypatch.setattr("autoteam.accounts.update_account", fake_update_account)
+    monkeypatch.setattr("autoteam.manager.cmd_rotate", lambda *args, **kwargs: None)
+    monkeypatch.setattr(api, "_start_task", lambda *args, **kwargs: None)
+    monkeypatch.setattr("time.time", lambda: 1000)
+
+    stop_event = api._auto_check_stop
+    wait_calls = {"count": 0}
+
+    def fake_wait(_seconds):
+        wait_calls["count"] += 1
+        return wait_calls["count"] > 1
+
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    api._auto_check_loop()
+
+    assert len(updates) == 1
+    low_update = updates[0][1]
+    assert low_update["status"] == "exhausted"
+    assert low_update["last_quota"] == {"primary_pct": 93, "weekly_pct": 1, "weekly_resets_at": 0}
+    assert low_update["quota_resets_at"] == 19000
+
+
+def test_auto_check_falls_back_when_exhausted_quota_has_no_reset_time(tmp_path, monkeypatch):
+    auth_file = tmp_path / "exhausted.json"
+    auth_file.write_text('{"access_token": "token-exhausted"}', encoding="utf-8")
+
+    updates = []
+
+    def fake_update_account(email, **kwargs):
+        updates.append((email, kwargs))
+
+    monkeypatch.setattr(api, "_auto_check_config", {"interval": 0, "threshold": 10, "min_low": 1})
+    monkeypatch.setattr(api, "_auto_check_stop", __import__("threading").Event())
+    monkeypatch.setattr(api, "_auto_check_restart", __import__("threading").Event())
+    monkeypatch.setattr(api, "_is_main_account_email", lambda _email: False)
+    monkeypatch.setattr(
+        "autoteam.accounts.load_accounts",
+        lambda: [{"email": "exhausted@example.com", "status": "active", "auth_file": str(auth_file)}],
+    )
+    monkeypatch.setattr(
+        "autoteam.codex_auth.check_codex_quota",
+        lambda _token: (
+            "exhausted",
+            {
+                "quota_info": {
+                    "primary_pct": 100,
+                    "weekly_pct": 100,
+                    "weekly_resets_at": 0,
+                }
+            },
+        ),
+    )
+    monkeypatch.setattr("autoteam.accounts.update_account", fake_update_account)
+    monkeypatch.setattr("autoteam.manager.cmd_rotate", lambda *args, **kwargs: None)
+    monkeypatch.setattr(api, "_start_task", lambda *args, **kwargs: None)
+    monkeypatch.setattr("time.time", lambda: 2000)
+
+    stop_event = api._auto_check_stop
+    wait_calls = {"count": 0}
+
+    def fake_wait(_seconds):
+        wait_calls["count"] += 1
+        return wait_calls["count"] > 1
+
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    api._auto_check_loop()
+
+    assert len(updates) == 1
+    exhausted_update = updates[0][1]
+    assert exhausted_update["status"] == "exhausted"
+    assert exhausted_update["last_quota"] == {
+        "primary_pct": 100,
+        "weekly_pct": 100,
+        "weekly_resets_at": 0,
+    }
+    assert exhausted_update["quota_resets_at"] == 20000
+
+
+def test_auto_check_triggers_rotate_when_active_count_is_below_target(tmp_path, monkeypatch):
+    auth_files = []
+    for idx in range(3):
+        auth_file = tmp_path / f"active-{idx}.json"
+        auth_file.write_text(json.dumps({"access_token": f"token-{idx}"}), encoding="utf-8")
+        auth_files.append(auth_file)
+
+    started = []
+
+    def fake_start_task(command, func, params, *args, **kwargs):
+        started.append(
+            {
+                "command": command,
+                "params": params,
+                "args": args,
+            }
+        )
+
+    monkeypatch.setattr(api, "_auto_check_config", {"interval": 0, "threshold": 10, "min_low": 2})
+    monkeypatch.setattr(api, "_auto_check_stop", __import__("threading").Event())
+    monkeypatch.setattr(api, "_auto_check_restart", __import__("threading").Event())
+    monkeypatch.setattr(api, "_is_main_account_email", lambda _email: False)
+    monkeypatch.setattr(
+        "autoteam.accounts.load_accounts",
+        lambda: [
+            {"email": f"active-{idx}@example.com", "status": "active", "auth_file": str(auth_files[idx])}
+            for idx in range(3)
+        ],
+    )
+    monkeypatch.setattr(
+        "autoteam.codex_auth.check_codex_quota",
+        lambda _token: ("ok", {"primary_pct": 10, "primary_resets_at": 1234567890, "weekly_pct": 1}),
+    )
+    monkeypatch.setattr("autoteam.accounts.update_account", lambda *args, **kwargs: None)
+    monkeypatch.setattr(api, "_start_task", fake_start_task)
+
+    stop_event = api._auto_check_stop
+    wait_calls = {"count": 0}
+
+    def fake_wait(_seconds):
+        wait_calls["count"] += 1
+        return wait_calls["count"] > 1
+
+    monkeypatch.setattr(stop_event, "wait", fake_wait)
+
+    api._auto_check_loop()
+
+    assert len(started) == 1
+    assert started[0]["command"] == "auto-rotate"
+    assert started[0]["params"]["target"] == 5
+    assert started[0]["params"]["trigger"] == "auto-check"
+    assert started[0]["params"]["shortage"] == 2
+    assert started[0]["params"]["low_accounts"] == 0
+    assert started[0]["args"] == (5,)


### PR DESCRIPTION
Fix auto-check fallback and retry rotate when active seats are below target
fix: #20 