### PR TITLE
修复禁用 Sub2API 后删除账号仍报 500 的问题

### DIFF
--- a/src/autoteam/sync_targets.py
+++ b/src/autoteam/sync_targets.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Mapping
 
 from autoteam.textio import parse_env_value
+
+logger = logging.getLogger(__name__)
 
 SYNC_TARGET_CPA = "cpa"
 SYNC_TARGET_SUB2API = "sub2api"
@@ -74,6 +77,10 @@ def get_available_sync_targets(env: Mapping[str, object] | None = None) -> list[
     values = _normalize_env(env)
     available = []
     for target, meta in _SYNC_TARGET_META.items():
+        toggle_key = str(meta["toggle_key"])
+        raw_toggle = (values.get(toggle_key) or "").strip()
+        if raw_toggle and not parse_bool_env(raw_toggle):
+            continue
         if all((values.get(key) or "").strip() for key in tuple(meta["config_keys"])):
             available.append(target)
     return available
@@ -152,12 +159,20 @@ def delete_main_codex_from_configured_targets(*, include_disabled: bool = False)
     if SYNC_TARGET_CPA in targets:
         from autoteam.cpa_sync import delete_main_codex_from_cpa
 
-        results[SYNC_TARGET_CPA] = delete_main_codex_from_cpa()
+        try:
+            results[SYNC_TARGET_CPA] = delete_main_codex_from_cpa()
+        except Exception as exc:
+            logger.warning("[CPA] 删除主号失败: %s", exc)
+            results[SYNC_TARGET_CPA] = {"deleted": [], "count": 0, "error": str(exc)}
 
     if SYNC_TARGET_SUB2API in targets:
         from autoteam.sub2api_sync import delete_main_codex_from_sub2api
 
-        results[SYNC_TARGET_SUB2API] = delete_main_codex_from_sub2api()
+        try:
+            results[SYNC_TARGET_SUB2API] = delete_main_codex_from_sub2api()
+        except Exception as exc:
+            logger.warning("[Sub2API] 删除主号失败: %s", exc)
+            results[SYNC_TARGET_SUB2API] = {"deleted": [], "count": 0, "error": str(exc)}
 
     return results
 
@@ -171,19 +186,27 @@ def delete_account_from_configured_targets(
     if SYNC_TARGET_CPA in targets:
         from autoteam.cpa_sync import delete_from_cpa, list_cpa_files
 
-        deleted = []
-        auth_name_set = set(auth_names or [])
-        for item in list_cpa_files():
-            item_email = (item.get("email") or "").lower()
-            item_name = item.get("name") or ""
-            if item_email == email.lower() or item_name in auth_name_set:
-                if delete_from_cpa(item_name):
-                    deleted.append(item_name)
-        results[SYNC_TARGET_CPA] = {"deleted": deleted, "count": len(deleted)}
+        try:
+            deleted = []
+            auth_name_set = set(auth_names or [])
+            for item in list_cpa_files():
+                item_email = (item.get("email") or "").lower()
+                item_name = item.get("name") or ""
+                if item_email == email.lower() or item_name in auth_name_set:
+                    if delete_from_cpa(item_name):
+                        deleted.append(item_name)
+            results[SYNC_TARGET_CPA] = {"deleted": deleted, "count": len(deleted)}
+        except Exception as exc:
+            logger.warning("[CPA] 删除账号 %s 失败: %s", email, exc)
+            results[SYNC_TARGET_CPA] = {"deleted": [], "count": 0, "error": str(exc)}
 
     if SYNC_TARGET_SUB2API in targets:
         from autoteam.sub2api_sync import delete_account_from_sub2api
 
-        results[SYNC_TARGET_SUB2API] = delete_account_from_sub2api(email, auth_names=auth_names or [])
+        try:
+            results[SYNC_TARGET_SUB2API] = delete_account_from_sub2api(email, auth_names=auth_names or [])
+        except Exception as exc:
+            logger.warning("[Sub2API] 删除账号 %s 失败: %s", email, exc)
+            results[SYNC_TARGET_SUB2API] = {"deleted": [], "count": 0, "error": str(exc)}
 
     return results


### PR DESCRIPTION
## 概述

修复仪表盘从 Team 移除账号时返回 `500 Internal Server Error` 的问题。

复现路径：用户在 `.env` 中显式设置 `SYNC_TARGET_SUB2API=false`，仅保留 SUB2API_URL/EMAIL/PASSWORD 的占位符值（`.env.example` 复制过来），点击删除账号 → 后端抛 `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` → 本地账号也没清理掉。

## 根因

`delete_account_from_configured_targets` 删除时使用 `include_disabled=True` 以兼容"先关同步、再清理残留"的场景，走的是 `get_available_sync_targets()` 分支。

而原始的 `get_available_sync_targets` 只检查配置项是否非空，**完全忽略了用户显式设置的 `SYNC_TARGET_*=false` 开关**。因为 `.env.example` 里 SUB2API 三项有占位值（`http://127.0.0.1:8080` / `admin@example.com` / `your_password`），仅复制过来就会让该函数判定 Sub2API "可用"，于是删除流程仍会尝试 `_login()`：

```
File "src/autoteam/sub2api_sync.py", line 79, in _request
    raise RuntimeError(f"[Sub2API] {label}返回了非 JSON 内容: {_excerpt(resp.text)}") from exc
RuntimeError: [Sub2API] 管理员登录返回了非 JSON 内容:
```

连接 `127.0.0.1:8080` 失败，响应体为空，JSON 解析炸开，异常一路冒到 FastAPI 变成 500，本地账号清理流程被中断。

## 修改

`src/autoteam/sync_targets.py`：

1. **`get_available_sync_targets` 尊重显式 `false` toggle**。如果用户写明 `SYNC_TARGET_SUB2API=false`，即使配置项有占位值也跳过该目标 —— 与 `get_sync_target_states` 的语义保持一致。toggle 未设置时仍按"配置齐全即可用"的旧行为处理，向后兼容。

2. **远端清理调用全部 `try/except` 包裹**。`delete_main_codex_from_configured_targets` / `delete_account_from_configured_targets` 中每个远端目标的删除调用单独捕获异常，失败时记 WARNING 日志并在 `results` 中带 `error` 字段返回。这样即便将来配置正确但远端临时不可达（网络抖动、服务重启等），本地账号删除也不会再被阻塞。

## Test plan

- [x] `.env` 中 `SYNC_TARGET_SUB2API=false` + 占位符配置，仪表盘删除账号不再 500
- [x] `.env` 未设置 toggle 但配置齐全时 sub2api 仍在 available 列表（向后兼容）
- [x] `SYNC_TARGET_SUB2API=true` 时仍可正常调用远端
- [ ] Sub2API 服务确实启用但不可达时，本地账号仍能删除，日志中能看到 `[Sub2API] 删除账号 xxx 失败` 的 warning