### PR TITLE
fix: main codex login password fallback

### DIFF
--- a/src/autoteam/codex_auth.py
+++ b/src/autoteam/codex_auth.py
@@ -1528,6 +1528,8 @@ class SessionCodexAuthFlow:
             if step == "password_required":
                 if self._switch_password_to_otp():
                     continue
+                if self._auto_fill_password():
+                    continue
                 return {
                     "step": "unsupported_password",
                     "detail": "主号 Codex 当前停留在密码页，且未找到一次性验证码入口",
@@ -1618,12 +1620,14 @@ class SessionCodexAuthFlow:
 
 class MainCodexLoginFlow(SessionCodexAuthFlow):
     def __init__(self):
+        from autoteam.admin_state import get_admin_password
+
         super().__init__(
             email=get_admin_email(),
             session_token=get_admin_session_token(),
             account_id=get_chatgpt_account_id(),
             workspace_name=get_chatgpt_workspace_name(),
-            password="",
+            password=get_admin_password(),
             password_callback=None,
             auth_file_callback=save_main_auth_file,
         )


### PR DESCRIPTION
## 问题

主号 Codex 登录流程（`MainCodexLoginFlow`）有两个 bug：

1. **密码页无 fallback**：`_advance()` 检测到 `password_required` 时，只尝试切换到 OTP 登录（`_switch_password_to_otp`）。但 Codex OAuth 页面（`auth.openai.com/sign-in-with-chatgpt/codex`）没有 OTP 选项，导致 OTP 切换必然失败后直接返回 `unsupported_password` 错误，流程中断。

2. **主号密码未传递**：`MainCodexLoginFlow.__init__` 硬编码 `password=""`，未读取管理员登录时已保存的密码（`get_admin_password()`），即使 fallback 到密码自动填充，填入的也是空字符串。

## 修复

- 在 OTP 切换失败后，增加 `_auto_fill_password()` 作为 fallback，用已保存的密码自动填入并提交
- `MainCodexLoginFlow` 初始化时通过 `get_admin_password()` 读取已保存的管理员密码

## 影响范围

仅影响 `MainCodexLoginFlow`（主号 Codex 登录），不影响 member 账号的登录流程。